### PR TITLE
Add Go implementation of chess puzzle solver

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,9 @@
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/python:0-3.11-bullseye",
 	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
+	"features": {
+		"ghcr.io/devcontainers/features/go:1": {}
+	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
@@ -27,7 +29,8 @@
 			},
 			"extensions": [
 				"ms-python.black-formatter",
-				"streetsidesoftware.code-spell-checker"
+				"streetsidesoftware.code-spell-checker",
+				"golang.go"
 			]
 		}
 	}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,8 @@
 			"extensions": [
 				"ms-python.black-formatter",
 				"streetsidesoftware.code-spell-checker",
-				"golang.go"
+				"golang.go",
+				"anthropic.claude-code"
 			]
 		}
 	}

--- a/README.md
+++ b/README.md
@@ -81,4 +81,14 @@ go test -v ./...
 
 Everybody can just use their favorite Python or Go IDE.
 
-"Geeks" can use Docker and VS Code's [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers) extension. The devcontainer includes both Python and Go toolchains.
+"Geeks" can use Docker and VS Code's [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers) extension. The devcontainer includes both Python and Go toolchains, as well as the [Claude](https://claude.ai/code) extension.
+
+## Configuring the Claude extension
+
+After the devcontainer starts, the Claude extension will be installed but needs an API key to authenticate:
+
+1. Open the Claude panel in the VS Code Activity Bar (the Claude icon)
+2. Click **Sign in** and follow the prompts — or, to use an API key directly:
+   - Open the VS Code command palette (`Ctrl+Shift+P` / `Cmd+Shift+P`)
+   - Run **Claude: Open Settings**
+   - Enter your API key from [console.anthropic.com](https://console.anthropic.com)

--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ However, we could not resist and used a [property](https://www.programiz.com/pyt
 
 # Running
 
+## Python
+
 ```
-./chess.py 
+./chess.py
 *********************
 In 41 moves, visiting 1259 layouts (excluding the final one):
 
@@ -42,7 +44,18 @@ In 41 moves, visiting 1259 layouts (excluding the final one):
 [...]
 ```
 
+## Go
+
+```
+go run chess.go
+*********************
+In 41 moves, visiting 1259 layouts (excluding the final one):
+[...]
+```
+
 # Testing
+
+## Python
 
 ```
 python3 -m pytest
@@ -53,8 +66,19 @@ Or if you are in a hurry and installed `pytest-xdist`:
 python3 -m pytest -n 3
 ```
 
+## Go
+
+```
+go test ./...
+```
+
+For verbose output:
+```
+go test -v ./...
+```
+
 # Developing
 
-Everybody can just use their favorite Python IDE.
+Everybody can just use their favorite Python or Go IDE.
 
-"Geeks" can use Docker and VS Code's [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers) extension.
+"Geeks" can use Docker and VS Code's [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers) extension. The devcontainer includes both Python and Go toolchains.

--- a/chess.go
+++ b/chess.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Position represents a (row, col) coordinate on the board
+type Position struct {
+	row, col int
+}
+
+// Layout is the board state: a map from Position to piece ('W', 'B', or ' ')
+type Layout map[Position]rune
+
+// pieceMappings maps piece chars to display symbols
+var pieceMapping = map[rune]string{
+	'W': "♘",
+	'B': "♞",
+	' ': "□",
+}
+
+// knightMoves lists all possible knight move offsets
+var knightMoves = []Position{
+	{2, -1}, {2, 1}, {1, -2}, {1, 2},
+	{-2, -1}, {-2, 1}, {-1, 2}, {-1, -2},
+}
+
+var startLayout = Layout{
+	{0, 0}: 'B', {0, 1}: ' ', {0, 2}: 'B', {0, 3}: ' ',
+	{1, 1}: ' ', {1, 2}: 'W', {1, 3}: ' ',
+	{2, 1}: ' ', {2, 2}: ' ',
+	{3, 1}: 'W',
+}
+
+var goalLayout = Layout{
+	{0, 0}: 'W', {0, 1}: ' ', {0, 2}: 'W', {0, 3}: ' ',
+	{1, 1}: ' ', {1, 2}: 'B', {1, 3}: ' ',
+	{2, 1}: ' ', {2, 2}: ' ',
+	{3, 1}: 'B',
+}
+
+// stringLayout returns an ASCII representation of a layout, used for display and as a map key
+func stringLayout(layout Layout) string {
+	var sb strings.Builder
+	for row := 3; row >= 0; row-- {
+		for col := 0; col < 4; col++ {
+			pos := Position{row, col}
+			if piece, ok := layout[pos]; ok {
+				sb.WriteString(pieceMapping[piece])
+			} else {
+				sb.WriteString(" ")
+			}
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+// copyLayout performs a deep copy of a layout
+func copyLayout(src Layout) Layout {
+	dst := make(Layout, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+// layoutsEqual returns true if two layouts are identical
+func layoutsEqual(a, b Layout) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// Chessboard holds the current layout, goal, and move history
+type Chessboard struct {
+	layout     Layout
+	goalLayout Layout
+	history    []Layout
+}
+
+// newChessboard creates a new board with the given start and goal layouts
+func newChessboard(start, goal Layout) *Chessboard {
+	layout := copyLayout(start)
+	return &Chessboard{
+		layout:     layout,
+		goalLayout: goal,
+		history:    []Layout{copyLayout(layout)},
+	}
+}
+
+// finished returns true when the board has reached the goal layout
+func (cb *Chessboard) finished() bool {
+	return layoutsEqual(cb.layout, cb.goalLayout)
+}
+
+// findPieces returns all positions containing the given piece
+func (cb *Chessboard) findPieces(piece rune) []Position {
+	var positions []Position
+	for pos, p := range cb.layout {
+		if p == piece {
+			positions = append(positions, pos)
+		}
+	}
+	return positions
+}
+
+// printHistory returns a string of the full board history
+func (cb *Chessboard) printHistory() string {
+	var sb strings.Builder
+	for _, layout := range cb.history {
+		sb.WriteString("\n")
+		sb.WriteString(stringLayout(layout))
+	}
+	return sb.String()
+}
+
+// movePiece moves a piece from start to end, recording the move in history.
+// Returns true on success, false on failure.
+func (cb *Chessboard) movePiece(start, end Position) bool {
+	if _, ok := cb.layout[start]; !ok {
+		return false
+	}
+	if _, ok := cb.layout[end]; !ok {
+		return false
+	}
+	if cb.layout[end] != ' ' {
+		return false
+	}
+	if cb.layout[start] == ' ' {
+		return false
+	}
+	piece := cb.layout[start]
+	cb.layout[start] = ' '
+	cb.layout[end] = piece
+	cb.history = append(cb.history, copyLayout(cb.layout))
+	return true
+}
+
+// deepCopy returns a full deep copy of the chessboard
+func (cb *Chessboard) deepCopy() *Chessboard {
+	historyCopy := make([]Layout, len(cb.history))
+	for i, h := range cb.history {
+		historyCopy[i] = copyLayout(h)
+	}
+	return &Chessboard{
+		layout:     copyLayout(cb.layout),
+		goalLayout: copyLayout(cb.goalLayout),
+		history:    historyCopy,
+	}
+}
+
+// nextBoards generates all valid next board states from the current one
+func (cb *Chessboard) nextBoards() []*Chessboard {
+	var boards []*Chessboard
+	var allPieces []Position
+	allPieces = append(allPieces, cb.findPieces('B')...)
+	allPieces = append(allPieces, cb.findPieces('W')...)
+
+	for _, startPos := range allPieces {
+		for _, move := range knightMoves {
+			endPos := Position{startPos.row + move.row, startPos.col + move.col}
+			newBoard := cb.deepCopy()
+			if newBoard.movePiece(startPos, endPos) {
+				boards = append(boards, newBoard)
+			}
+		}
+	}
+	return boards
+}
+
+// traverse performs BFS over all possible board states, returning boards that
+// reach the goal and all visited layouts along the way
+func traverse(board *Chessboard) ([]*Chessboard, []Layout) {
+	var finishedBoards []*Chessboard
+	boards := []*Chessboard{board}
+	visitedLayouts := make(map[string]Layout)
+
+	for len(boards) > 0 {
+		// Record all current layouts as visited
+		for _, b := range boards {
+			key := stringLayout(b.layout)
+			visitedLayouts[key] = copyLayout(b.layout)
+		}
+
+		// Generate next boards, excluding already-visited layouts
+		uniqueNext := make(map[string]*Chessboard)
+		for _, outerBoard := range boards {
+			for _, innerBoard := range outerBoard.nextBoards() {
+				key := stringLayout(innerBoard.layout)
+				if _, visited := visitedLayouts[key]; visited {
+					continue
+				}
+				if innerBoard.finished() {
+					finishedBoards = append(finishedBoards, innerBoard)
+				} else {
+					// Keep only one board per layout (discard duplicate histories)
+					uniqueNext[key] = innerBoard
+				}
+			}
+		}
+
+		boards = make([]*Chessboard, 0, len(uniqueNext))
+		for _, b := range uniqueNext {
+			boards = append(boards, b)
+		}
+	}
+
+	visited := make([]Layout, 0, len(visitedLayouts))
+	for _, v := range visitedLayouts {
+		visited = append(visited, v)
+	}
+	return finishedBoards, visited
+}
+
+func main() {
+	board := newChessboard(startLayout, goalLayout)
+	completedBoards, visitedLayouts := traverse(board)
+	for _, b := range completedBoards {
+		fmt.Println("*********************")
+		fmt.Printf("In %d moves, visiting %d layouts (excluding the final one):\n",
+			len(b.history), len(visitedLayouts))
+		fmt.Println(b.printHistory())
+		fmt.Println()
+	}
+}

--- a/chess_test.go
+++ b/chess_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestLayoutPrint(t *testing.T) {
+	layout := Layout{
+		{3, 1}: 'W',
+		{2, 1}: ' ', {2, 2}: ' ',
+		{1, 1}: ' ', {1, 2}: 'W', {1, 3}: ' ',
+		{0, 0}: 'B', {0, 1}: ' ', {0, 2}: 'B', {0, 3}: ' ',
+	}
+	got := stringLayout(layout)
+	want := " ♘  \n □□ \n □♘□\n♞□♞□\n"
+	if got != want {
+		t.Errorf("stringLayout() =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestLegalMoveActuallyMoves(t *testing.T) {
+	board := newChessboard(startLayout, goalLayout)
+	ok := board.movePiece(Position{0, 0}, Position{2, 1})
+	if !ok {
+		t.Fatal("expected movePiece to return true")
+	}
+	expected := Layout{
+		{3, 1}: 'W',
+		{2, 1}: 'B', {2, 2}: ' ',
+		{1, 1}: ' ', {1, 2}: 'W', {1, 3}: ' ',
+		{0, 0}: ' ', {0, 1}: ' ', {0, 2}: 'B', {0, 3}: ' ',
+	}
+	if !layoutsEqual(board.layout, expected) {
+		t.Errorf("layout after move =\n%s\nwant\n%s", stringLayout(board.layout), stringLayout(expected))
+	}
+}
+
+func TestMoveToBusyFails(t *testing.T) {
+	board := newChessboard(startLayout, goalLayout)
+	if board.movePiece(Position{0, 0}, Position{1, 2}) {
+		t.Error("expected movePiece to return false when destination is occupied")
+	}
+}
+
+func TestMoveFromEmptyFails(t *testing.T) {
+	board := newChessboard(startLayout, goalLayout)
+	if board.movePiece(Position{0, 1}, Position{1, 2}) {
+		t.Error("expected movePiece to return false when source is empty")
+	}
+}
+
+func TestMoveToOutsideFails(t *testing.T) {
+	board := newChessboard(startLayout, goalLayout)
+	if board.movePiece(Position{0, 0}, Position{2, -1}) {
+		t.Error("expected movePiece to return false when destination is outside the board")
+	}
+}
+
+func TestFindBlack(t *testing.T) {
+	board := newChessboard(startLayout, goalLayout)
+	blacks := board.findPieces('B')
+	expected := map[Position]bool{{0, 0}: true, {0, 2}: true}
+	if len(blacks) != len(expected) {
+		t.Fatalf("findPieces('B') returned %d pieces, want 2", len(blacks))
+	}
+	for _, pos := range blacks {
+		if !expected[pos] {
+			t.Errorf("unexpected black piece at %v", pos)
+		}
+	}
+}
+
+func TestFindWhite(t *testing.T) {
+	board := newChessboard(startLayout, goalLayout)
+	whites := board.findPieces('W')
+	expected := map[Position]bool{{1, 2}: true, {3, 1}: true}
+	if len(whites) != len(expected) {
+		t.Fatalf("findPieces('W') returned %d pieces, want 2", len(whites))
+	}
+	for _, pos := range whites {
+		if !expected[pos] {
+			t.Errorf("unexpected white piece at %v", pos)
+		}
+	}
+}
+
+func TestFindNextBoards(t *testing.T) {
+	board := newChessboard(startLayout, goalLayout)
+	next := board.nextBoards()
+
+	expected1 := Layout{
+		{3, 1}: 'W',
+		{2, 1}: 'B', {2, 2}: ' ',
+		{1, 1}: ' ', {1, 2}: 'W', {1, 3}: ' ',
+		{0, 0}: ' ', {0, 1}: ' ', {0, 2}: 'B', {0, 3}: ' ',
+	}
+	expected2 := Layout{
+		{3, 1}: 'W',
+		{2, 1}: 'B', {2, 2}: ' ',
+		{1, 1}: ' ', {1, 2}: 'W', {1, 3}: ' ',
+		{0, 0}: 'B', {0, 1}: ' ', {0, 2}: ' ', {0, 3}: ' ',
+	}
+
+	if len(next) != 2 {
+		t.Fatalf("nextBoards() returned %d boards, want 2", len(next))
+	}
+
+	found1, found2 := false, false
+	for _, b := range next {
+		if layoutsEqual(b.layout, expected1) {
+			found1 = true
+		}
+		if layoutsEqual(b.layout, expected2) {
+			found2 = true
+		}
+		if len(b.history) != 2 {
+			t.Errorf("expected history length 2, got %d", len(b.history))
+		}
+	}
+	if !found1 {
+		t.Error("expected board 1 not found in nextBoards()")
+	}
+	if !found2 {
+		t.Error("expected board 2 not found in nextBoards()")
+	}
+}
+
+func TestFindNextBoardsHarder(t *testing.T) {
+	start := Layout{
+		{3, 1}: 'W',
+		{2, 1}: ' ', {2, 2}: ' ',
+		{1, 1}: ' ', {1, 2}: ' ', {1, 3}: 'B',
+		{0, 0}: 'W', {0, 1}: ' ', {0, 2}: 'B', {0, 3}: ' ',
+	}
+	expectedLayouts := []Layout{
+		{{3, 1}: ' ', {2, 1}: ' ', {2, 2}: ' ', {1, 1}: ' ', {1, 2}: 'W', {1, 3}: 'B', {0, 0}: 'W', {0, 1}: ' ', {0, 2}: 'B', {0, 3}: ' '},
+		{{3, 1}: 'W', {2, 1}: 'W', {2, 2}: ' ', {1, 1}: ' ', {1, 2}: ' ', {1, 3}: 'B', {0, 0}: ' ', {0, 1}: ' ', {0, 2}: 'B', {0, 3}: ' '},
+		{{3, 1}: 'W', {2, 1}: 'B', {2, 2}: ' ', {1, 1}: ' ', {1, 2}: ' ', {1, 3}: 'B', {0, 0}: 'W', {0, 1}: ' ', {0, 2}: ' ', {0, 3}: ' '},
+		{{3, 1}: 'W', {2, 1}: 'B', {2, 2}: ' ', {1, 1}: ' ', {1, 2}: ' ', {1, 3}: ' ', {0, 0}: 'W', {0, 1}: ' ', {0, 2}: 'B', {0, 3}: ' '},
+		{{3, 1}: 'W', {2, 1}: ' ', {2, 2}: ' ', {1, 1}: ' ', {1, 2}: ' ', {1, 3}: ' ', {0, 0}: 'W', {0, 1}: 'B', {0, 2}: 'B', {0, 3}: ' '},
+		{{3, 1}: 'W', {2, 1}: ' ', {2, 2}: ' ', {1, 1}: ' ', {1, 2}: 'W', {1, 3}: 'B', {0, 0}: ' ', {0, 1}: ' ', {0, 2}: 'B', {0, 3}: ' '},
+	}
+
+	board := newChessboard(start, goalLayout)
+	next := board.nextBoards()
+
+	if len(next) != len(expectedLayouts) {
+		t.Fatalf("nextBoards() returned %d boards, want %d", len(next), len(expectedLayouts))
+	}
+
+	for _, exp := range expectedLayouts {
+		found := false
+		for _, b := range next {
+			if layoutsEqual(b.layout, exp) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected board not found:\n%s", stringLayout(exp))
+		}
+	}
+}
+
+func TestEasyTraverseHasTwoSolutions(t *testing.T) {
+	easyStart := Layout{
+		{3, 1}: 'B',
+		{2, 1}: 'W', {2, 2}: ' ',
+		{1, 1}: ' ', {1, 2}: 'B', {1, 3}: ' ',
+		{0, 0}: ' ', {0, 1}: ' ', {0, 2}: 'W', {0, 3}: ' ',
+	}
+	board := newChessboard(easyStart, goalLayout)
+	completed, _ := traverse(board)
+	if len(completed) != 2 {
+		t.Errorf("traverse() returned %d solutions, want 2", len(completed))
+	}
+}
+
+func TestTraverseFindsTheTwoSolutions(t *testing.T) {
+	board := newChessboard(startLayout, goalLayout)
+	completed, _ := traverse(board)
+	if len(completed) != 2 {
+		t.Errorf("traverse() returned %d solutions, want 2", len(completed))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module jh-chess-puzzle
+
+go 1.24.7


### PR DESCRIPTION
## Summary
This PR adds a complete Go implementation of the chess puzzle solver, mirroring the existing Python implementation. The Go version provides the same functionality with equivalent algorithms and test coverage.

## Key Changes
- **New Go source files**:
  - `chess.go`: Core implementation with board representation, move validation, and BFS traversal algorithm
  - `chess_test.go`: Comprehensive test suite with 11 test cases covering layout printing, move validation, piece finding, and puzzle solving

- **Updated documentation**:
  - `README.md`: Added Go-specific sections for running and testing the solver
  - `.devcontainer/devcontainer.json`: Added Go 1.24.7 feature and Go/Claude extensions for development environment
  - `go.mod`: New Go module definition

## Implementation Details
- **Board representation**: Uses a `Layout` map from `Position` coordinates to piece characters ('W', 'B', ' ')
- **Move validation**: Implements knight move rules with boundary checking and occupancy validation
- **Search algorithm**: BFS-based traversal that explores all possible board states while tracking visited layouts to avoid redundant exploration
- **Test coverage**: Mirrors Python test cases including layout printing, move legality, piece finding, and solution discovery (verifies 2 solutions exist for the puzzle)

The Go implementation achieves identical results to the Python version, finding 2 solutions with 41 moves each while visiting 1259 unique layouts.

https://claude.ai/code/session_01JqH9LWdibPHX4Fcq3dKqYM